### PR TITLE
save only necessary auth fields in local storage

### DIFF
--- a/src/contexts/Auth/authProvider/AuthProvider.tsx
+++ b/src/contexts/Auth/authProvider/AuthProvider.tsx
@@ -14,7 +14,7 @@ const AuthProvider: React.FC<AuthProviderProps> = ({ children, authState }) => {
   const defaultStateWithServices = { ...DefaultState, ...authState }
   const [state, dispatch] = useReducer(authReducer, defaultStateWithServices)
 
-  useHydrateState(state, dispatch)
+  useHydrateState(state, dispatch, ['jwtToken', 'loggedInAccount'])
 
   const value = { dispatch, state }
 


### PR DESCRIPTION
Make it so we only keep what we will need to rehydrate in localstorage and wipe it clean once we load the app so any new state values from code will take precedence