### PR TITLE
add `?` to prevent the `null` issue

### DIFF
--- a/src/components/TableCell/getRemainingRowWidth.ts
+++ b/src/components/TableCell/getRemainingRowWidth.ts
@@ -8,10 +8,10 @@ export const getRemainingRowWidth = (row: HTMLElement, forCell = 0) => {
         width += item?.clientWidth ?? 0
       }
       padding += parseInt(
-        window.getComputedStyle(item, null)?.getPropertyValue('padding-left').replaceAll('px', '') ?? 0
+        window.getComputedStyle(item, null)?.getPropertyValue('padding-left')?.replaceAll('px', '') ?? 0
       )
       padding += parseInt(
-        window.getComputedStyle(item, null)?.getPropertyValue('padding-right').replaceAll('px', '') ?? 0
+        window.getComputedStyle(item, null)?.getPropertyValue('padding-right')?.replaceAll('px', '') ?? 0
       )
     }
   }


### PR DESCRIPTION
add `?` before `replaceAll` method to prevent the `undefined` value of the previous value.